### PR TITLE
Exclude docs from distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+docs/ export-ignore


### PR DESCRIPTION
## Summary
- add export-ignore rule to omit the built docs directory from distribution archives, reducing package download size

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a0d37acec832089a7ecd30817c759)